### PR TITLE
Add assertions to document important assumptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ shadowJar {
     archiveClassifier = null
 }
 
-run{
+run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/jett/Jett.java
+++ b/src/main/java/jett/Jett.java
@@ -21,6 +21,7 @@ public class Jett {
      * @param filePath Path to the data file where tasks are stored.
      */
     public Jett(String filePath) {
+        assert filePath != null && !filePath.isBlank() : "Storage path must be non-empty";
         ui = new Ui();
         storage = new Storage(filePath);
         try {
@@ -29,6 +30,7 @@ public class Jett {
             System.out.println(ui.getError("Loading error. Starting with an empty list."));
             list = new TaskList();
         }
+        assert list != null : "TaskList must be initialised";
     }
 
     public String getGreeting() {
@@ -36,14 +38,17 @@ public class Jett {
     }
 
     public String getResponse(String input) {
+        assert input != null : "input must not be null";
+        String response;
         try {
-            String response = Parser.respondToUser(input, list);
+            response = Parser.respondToUser(input, list);
             storage.saveNow(list);
-            return response;
         } catch (JettException e) {
-            return ui.getError(e.getMessage());
+            response = ui.getError(e.getMessage());
         } catch (Exception e) {
-            return ui.getError("Try again.");
+            response = ui.getError("Try again.");
         }
+        assert response != null && !response.isEmpty() : "response must be non-empty";
+        return response;
     }
 }

--- a/src/main/java/jett/Parser.java
+++ b/src/main/java/jett/Parser.java
@@ -13,7 +13,9 @@ public class Parser {
 
         static Command from(String input) {
             // Isolate the command
+            assert input != null : "from(): input must not be null";
             String cmd = input.trim().split("\\s+", 2)[0].toLowerCase();
+            assert !cmd.isEmpty() : "from(): command keyword must not be empty";
             return switch (cmd) {
             case "list" -> LIST;
             case "mark" -> MARK;
@@ -40,12 +42,15 @@ public class Parser {
      *                       or contains an invalid command
      */
     public static String respondToUser(String userInput, TaskList list) throws JettException {
+        assert list != null : "list must not be null";
+
         // Blank user input
         if (userInput.isBlank()) {
             throw new JettException("What can I do for you?");
         }
 
         Command cmd = Command.from(userInput);
+        assert cmd != null : "Command.from must not return null";
 
         switch (cmd) {
         case LIST: // User input = "list"
@@ -53,17 +58,21 @@ public class Parser {
 
         case MARK: // User input = "mark"
             Task markedTask = list.get(getTaskNumber(userInput, "mark", list) - 1);
+            assert markedTask != null : "marked task should exist";
             markedTask.mark();
             return "Nice! I've marked this task as done:\n" + markedTask;
 
         case UNMARK: // User input = "unmark"
             Task unmarkedTask = list.get(getTaskNumber(userInput, "unmark", list) - 1);
+            assert unmarkedTask != null : "unmarked task should exist";
             unmarkedTask.unmark();
             return "OK, I've marked this task as not done yet:\n" + unmarkedTask;
 
         case DELETE: // User input = "delete"
+            int sizeBeforeDelete = list.size();
             int taskNumber = getTaskNumber(userInput, "delete", list);
             Task removedTask = list.remove(taskNumber - 1);
+            assert list.size() == sizeBeforeDelete - 1 : "size must decrease by 1 after deleting a task";
             return "Noted. I've removed this task:\n"
                     + removedTask
                     + "\nNow you have " + list.size() + (list.size() == 1 ? " task" : " tasks") + " in the list.";
@@ -76,8 +85,11 @@ public class Parser {
             if (todoDesc.isEmpty()) {
                 throw new JettException("Fill in the description of your todo (e.g. todo read book)");
             }
+            int sizeBeforeTodo = list.size();
             Task todoTask = new Todo(todoDesc);
+            assert todoTask != null : "new Todo must not be null";
             list.add(todoTask);
+            assert list.size() == sizeBeforeTodo + 1 : "size must increase by 1 after adding a task";
             return "Got it. I've added this task:\n"
                     + todoTask
                     + "\nNow you have " + list.size() + (list.size() == 1 ? " task" : " tasks") + " in the list.";
@@ -99,12 +111,16 @@ public class Parser {
                         "Fill in the description and time of your deadline (e.g. deadline do report /by Sep 6 2025)"
                 );
             }
+            int sizeBeforeDeadline = list.size();
             try {
                 Task deadlineTask = new Deadline(deadlineDesc, by);
+                assert deadlineTask != null : "new Deadline must not be null";
                 list.add(deadlineTask);
             } catch (IllegalArgumentException e) {
                 throw new JettException("Use valid date format, e.g. 2025-09-06, 6/9/2025, Sep 6 2025");
             }
+            assert list.size() == sizeBeforeDeadline + 1 : "size must increase by 1 after adding a task";
+            assert list.get(list.size() - 1) != null : "last added task must not be null";
             return "Got it. I've added this task:\n"
                     + list.get(list.size() - 1)
                     + "\nNow you have " + list.size() + (list.size() == 1 ? " task" : " tasks") + " in the list.";
@@ -131,12 +147,16 @@ public class Parser {
                         "Fill in the description, start and end date (e.g. event camp /from Sep 6 2025 /to Sep 7 2025)"
                 );
             }
+            int sizeBeforeEvent = list.size();
             try {
                 Task newTask = new Event(eventDesc, from, to);
+                assert newTask != null : "new Event must not be null";
                 list.add(newTask);
             } catch (IllegalArgumentException e) {
                 throw new JettException("Use valid date format, e.g. 2025-09-06, 6/9/2025, Sep 6 2025");
             }
+            assert list.size() == sizeBeforeEvent + 1 : "size must increase by 1 after add";
+            assert list.get(list.size() - 1) != null : "last added task must not be null";
             return "Got it. I've added this task:\n"
                     + list.get(list.size() - 1)
                     + "\nNow you have " + list.size() + (list.size() == 1 ? " task" : " tasks") + " in the list.";

--- a/src/main/java/jett/Storage.java
+++ b/src/main/java/jett/Storage.java
@@ -20,6 +20,7 @@ public class Storage {
      * @param filePath path to the data file (e.g., {@code data/Jett.txt})
      */
     public Storage(String filePath) {
+        assert filePath != null && !filePath.isBlank() : "Storage path must be non-empty";
         this.filePath = filePath;
     }
 
@@ -31,20 +32,26 @@ public class Storage {
      * @param list the list of tasks to persist
      */
     public void saveNow(TaskList list) {
+        assert list != null : "Cannot save null TaskList";
         try {
             File file = new File(filePath);
             File parent = file.getParentFile();
             if (parent != null && !parent.exists()) {
+                assert !parent.isFile() : "Parent path exists as a file, cannot create directory";
                 parent.mkdirs();
+                assert parent.exists() && parent.isDirectory() : "Failed to create parent directory";
             }
 
             try (FileWriter fw = new FileWriter(filePath)) {
                 for (int i = 0; i < list.size(); i++) {
                     Task t = list.get(i);
+                    assert t != null : "TaskList must not contain null entries";
                     fw.write(t.toString());
                     fw.write(System.lineSeparator());
                 }
             }
+            assert file.exists() : "Data file should exist after save";
+            assert file.isFile() : "Data path should be a regular file after save";
         } catch (IOException e) {
             System.out.println("Something went wrong: " + e.getMessage());
         }
@@ -86,6 +93,7 @@ public class Storage {
                 scanner.close();
             }
         }
+        assert list != null : "getData must not return null";
         return list;
     }
 
@@ -97,6 +105,8 @@ public class Storage {
      * @return a {@link Task} instance, or {@code null} if unparseable
      */
     protected static Task parseLine(String line) {
+        assert line != null : "parseLine: input must not be null";
+
         // Corrupted data (not in expected format)
         if (line.charAt(0) != '[' || line.length() < 6) {
             return null;
@@ -117,6 +127,7 @@ public class Storage {
 
         // Obtain the task description and timings (if any)
         String rest = line.substring(secondClose + 1).trim();
+        assert !rest.startsWith("]") : "Text content should follow status brackets";
 
         Task t = null;
         switch (taskType) {

--- a/src/main/java/jett/TaskList.java
+++ b/src/main/java/jett/TaskList.java
@@ -50,6 +50,7 @@ public class TaskList {
      * @return the {@link Task} at the given index
      */
     public Task get(int index) {
+        assert index >= 0 && index < size() : "Index out of bounds";
         return tasks.get(index);
     }
 
@@ -59,6 +60,7 @@ public class TaskList {
      * @param t the {@link Task} to add
      */
     public void add(Task t) {
+        assert t != null : "Cannot add null task";
         tasks.add(t);
     }
 
@@ -69,6 +71,7 @@ public class TaskList {
      * @return the removed {@link Task}
      */
     public Task remove(int index) {
+        assert index >= 0 && index < size() : "Index out of bounds";
         return tasks.remove(index);
     }
 


### PR DESCRIPTION
The codebase lacks internal checks that document assumptions about method inputs, class invariants and postconditions. While exceptions are used for user errors, there are no developer-facing checks to catch logic bugs for format-drift early.

Let's add Java assert statements at key points in core classes (Jett, Parser, Storage and TaskList) to enforce these invariants during development.

Using assert instead of exceptions ensure we distinguish between user-facing validation and developer-facing sanity checks.